### PR TITLE
Support spell checking `camelCased` identifiers

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
-use wizard::dictionary::Dictionary;
-use wizard::wordifier::Wordifier;
+use crate::dictionary::Dictionary;
+use crate::wordifier::Wordifier;
 
 use crate::error::Error;
 

--- a/src/dictionary/basic.rs
+++ b/src/dictionary/basic.rs
@@ -17,6 +17,16 @@ impl BasicDictionary {
 
         Ok(Self(words))
     }
+
+    pub fn learn(&mut self, word: &str) {
+        self.0.insert(word.to_lowercase());
+    }
+}
+
+impl Default for BasicDictionary {
+    fn default() -> Self {
+        Self(HashSet::new())
+    }
 }
 
 impl super::Dictionary for BasicDictionary {

--- a/src/dictionary/basic.rs
+++ b/src/dictionary/basic.rs
@@ -6,6 +6,15 @@ use std::path::Path;
 pub struct BasicDictionary(HashSet<String>);
 
 impl BasicDictionary {
+    pub fn new<T: IntoIterator<Item: AsRef<str>>>(words: T) -> Self {
+        Self(
+            words
+                .into_iter()
+                .map(|word| word.as_ref().to_lowercase())
+                .collect(),
+        )
+    }
+
     pub fn from_file<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
         let f = File::open(path)?;
 
@@ -16,10 +25,6 @@ impl BasicDictionary {
             .collect();
 
         Ok(Self(words))
-    }
-
-    pub fn learn(&mut self, word: &str) {
-        self.0.insert(word.to_lowercase());
     }
 }
 
@@ -32,5 +37,39 @@ impl Default for BasicDictionary {
 impl super::Dictionary for BasicDictionary {
     fn contains(&self, word: &str) -> bool {
         self.0.contains(&word.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dictionary::Dictionary;
+
+    use super::BasicDictionary;
+
+    fn small_dictionary() -> BasicDictionary {
+        BasicDictionary::new(["a", "an", "Bird"])
+    }
+
+    #[test]
+    fn learned_spell() {
+        let d = small_dictionary();
+
+        assert!(d.contains("a"));
+        assert!(d.contains("an"));
+        assert!(d.contains("Bird"));
+    }
+
+    #[test]
+    fn did_not_learn_misspelled() {
+        assert!(!small_dictionary().contains("birdy"));
+    }
+
+    #[test]
+    fn learned_spell_insensitively() {
+        let d = small_dictionary();
+
+        assert!(d.contains("A"));
+        assert!(d.contains("aN"));
+        assert!(d.contains("Bird"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[derive(PartialEq, Eq, Debug)]
 pub struct Error<'a> {
     line: &'a str,
     error: &'a str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,10 @@ impl<'a> Error<'a> {
     pub(crate) fn new(line: &'a str, error: &'a str) -> Self {
         Self { line, error }
     }
+
+    pub fn typo(&self) -> &str {
+        self.error
+    }
 }
 
 impl std::fmt::Display for Error<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod test {
     use crate::{
         core::Wizard,
         dictionary::{BasicDictionary, Dictionary},
-        wordifier::{self, BasicWordifier, CamelCaseWordifier},
+        wordifier::{BasicWordifier, CamelCaseWordifier},
     };
 
     fn small_dictionary() -> BasicDictionary {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,83 @@
+pub mod core;
 pub mod dictionary;
+pub mod error;
 pub mod wordifier;
+
+pub use core::Wizard;
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        core::Wizard,
+        dictionary::{BasicDictionary, Dictionary},
+        wordifier::BasicWordifier,
+    };
+
+    fn small_dictionary() -> BasicDictionary {
+        let mut d = BasicDictionary::default();
+
+        d.learn("a");
+        d.learn("an");
+        d.learn("Bird");
+
+        d
+    }
+
+    #[test]
+    fn learned_spell() {
+        let d = small_dictionary();
+
+        assert!(d.contains("a"));
+        assert!(d.contains("an"));
+        assert!(d.contains("Bird"));
+    }
+
+    #[test]
+    fn did_not_learn_misspelled() {
+        assert!(!small_dictionary().contains("birdy"));
+    }
+
+    #[test]
+    fn learned_spell_insensitively() {
+        let d = small_dictionary();
+
+        assert!(d.contains("A"));
+        assert!(d.contains("aN"));
+        assert!(d.contains("Bird"));
+    }
+
+    fn basic_wizard() -> Wizard<BasicDictionary, BasicWordifier> {
+        Wizard {
+            dictionary: small_dictionary(),
+            wordifier: BasicWordifier,
+        }
+    }
+
+    #[test]
+    fn phrase() {
+        assert!(basic_wizard().errors("a bird").next().is_none());
+    }
+
+    #[test]
+    fn phrase_with_a_misspelled_word() {
+        let wizard = basic_wizard();
+        let mut errors = wizard.errors("a birdy");
+
+        assert_eq!(errors.next().unwrap().typo(), "birdy");
+        assert!(errors.next().is_none());
+    }
+
+    #[test]
+    fn snake_cased_identifier() {
+        let wizard = basic_wizard();
+
+        assert!(wizard.errors("a_bird").next().is_none());
+    }
+
+    #[test]
+    fn camel_cased_identifier() {
+        let wizard = basic_wizard();
+
+        assert!(wizard.errors("aBird").next().is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,43 +7,16 @@ pub use core::Wizard;
 
 #[cfg(test)]
 mod test {
+    use std::vec;
+
     use crate::{
         core::Wizard,
-        dictionary::{BasicDictionary, Dictionary},
+        dictionary::BasicDictionary,
         wordifier::{BasicWordifier, CamelCaseWordifier},
     };
 
     fn small_dictionary() -> BasicDictionary {
-        let mut d = BasicDictionary::default();
-
-        d.learn("a");
-        d.learn("an");
-        d.learn("Bird");
-
-        d
-    }
-
-    #[test]
-    fn learned_spell() {
-        let d = small_dictionary();
-
-        assert!(d.contains("a"));
-        assert!(d.contains("an"));
-        assert!(d.contains("Bird"));
-    }
-
-    #[test]
-    fn did_not_learn_misspelled() {
-        assert!(!small_dictionary().contains("birdy"));
-    }
-
-    #[test]
-    fn learned_spell_insensitively() {
-        let d = small_dictionary();
-
-        assert!(d.contains("A"));
-        assert!(d.contains("aN"));
-        assert!(d.contains("Bird"));
+        BasicDictionary::new(["a", "an", "Bird"])
     }
 
     fn basic_wizard() -> Wizard<BasicDictionary, BasicWordifier> {
@@ -54,24 +27,22 @@ mod test {
     }
 
     #[test]
-    fn phrase() {
-        assert!(basic_wizard().errors("a bird").next().is_none());
-    }
-
-    #[test]
     fn phrase_with_a_misspelled_word() {
         let wizard = basic_wizard();
-        let mut errors = wizard.errors("a birdy");
 
-        assert_eq!(errors.next().unwrap().typo(), "birdy");
-        assert!(errors.next().is_none());
+        let errors = wizard
+            .errors("a birdy")
+            .map(|e| e.typo().to_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(errors, vec!["birdy"]);
     }
 
     #[test]
     fn snake_cased_identifier() {
         let wizard = basic_wizard();
 
-        assert!(wizard.errors("a_bird").next().is_none());
+        assert_eq!(wizard.errors("a_bird").collect::<Vec<_>>(), vec![]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,14 @@ mod test {
             wordifier: CamelCaseWordifier,
         };
 
-        assert!(wizard.errors("aBird").next().is_none());
+        assert!(wizard.errors(r#"aBird = "bird""#).next().is_none());
+
+        assert_eq!(
+            wizard
+                .errors(r#"aBirb = "birb""#)
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>(),
+            vec![r#"a~~Birb~~ = "birb""#, r#"aBirb = "~~birb~~""#]
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod test {
     use crate::{
         core::Wizard,
         dictionary::{BasicDictionary, Dictionary},
-        wordifier::BasicWordifier,
+        wordifier::{self, BasicWordifier, CamelCaseWordifier},
     };
 
     fn small_dictionary() -> BasicDictionary {
@@ -76,7 +76,10 @@ mod test {
 
     #[test]
     fn camel_cased_identifier() {
-        let wizard = basic_wizard();
+        let wizard = Wizard {
+            dictionary: small_dictionary(),
+            wordifier: CamelCaseWordifier,
+        };
 
         assert!(wizard.errors("aBird").next().is_none());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,8 @@
-mod core;
-mod error;
-
 use std::io::stdin;
 
 use wizard::dictionary::BasicDictionary;
 use wizard::wordifier::BasicWordifier;
-
-use core::Wizard;
+use wizard::Wizard;
 
 fn main() -> std::io::Result<()> {
     let arg = std::env::args().nth(1);

--- a/src/wordifier/basic.rs
+++ b/src/wordifier/basic.rs
@@ -11,3 +11,40 @@ impl super::Wordifier for BasicWordifier {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wordifier::{BasicWordifier, Wordifier};
+
+    #[test]
+    fn it_works() {
+        assert_eq!(
+            BasicWordifier.words("this is good").collect::<Vec<_>>(),
+            vec!["this", "is", "good"]
+        )
+    }
+
+    #[test]
+    fn with_punctuation() {
+        assert_eq!(
+            BasicWordifier.words("Hello, world!").collect::<Vec<_>>(),
+            vec!["Hello", "world"]
+        )
+    }
+
+    #[test]
+    fn with_underscores() {
+        assert_eq!(
+            BasicWordifier.words("basic_wordifier").collect::<Vec<_>>(),
+            vec!["basic", "wordifier"]
+        )
+    }
+
+    #[test]
+    fn does_not_split_camel_case() {
+        assert_ne!(
+            BasicWordifier.words("basicWordifier").collect::<Vec<_>>(),
+            vec!["basic", "Wordifier"]
+        )
+    }
+}

--- a/src/wordifier/camel.rs
+++ b/src/wordifier/camel.rs
@@ -12,3 +12,18 @@ impl Wordifier for CamelCaseWordifier {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::wordifier::{CamelCaseWordifier, Wordifier};
+
+    #[test]
+    fn it_works() {
+        assert_eq!(
+            CamelCaseWordifier
+                .words("basicWordifier")
+                .collect::<Vec<_>>(),
+            vec!["basic", "Wordifier"]
+        )
+    }
+}

--- a/src/wordifier/camel.rs
+++ b/src/wordifier/camel.rs
@@ -1,13 +1,14 @@
 use super::iter::Iter;
+use super::Wordifier;
 
-pub struct BasicWordifier;
+pub struct CamelCaseWordifier;
 
-impl super::Wordifier for BasicWordifier {
+impl Wordifier for CamelCaseWordifier {
     fn words<'a>(&self, line: &'a str) -> impl Iterator<Item = &'a str> {
         Iter {
             line,
             word_begin: char::is_alphabetic,
-            word_end: |c: char| !c.is_alphabetic() && c != '\'',
+            word_end: |c: char| c.is_ascii_uppercase() || !c.is_alphabetic() && c != '\'',
         }
     }
 }

--- a/src/wordifier/iter.rs
+++ b/src/wordifier/iter.rs
@@ -1,0 +1,24 @@
+pub struct Iter<'a> {
+    pub line: &'a str,
+    pub word_begin: fn(char) -> bool,
+    pub word_end: fn(char) -> bool,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let word_start = self.line.find(self.word_begin)?;
+
+        let word_end = self.line[word_start..]
+            .find(self.word_end)
+            .map(|i| i + word_start)
+            .unwrap_or(self.line.len());
+
+        let word = &self.line[word_start..word_end];
+
+        self.line = &self.line[word_end..];
+
+        Some(word)
+    }
+}

--- a/src/wordifier/iter.rs
+++ b/src/wordifier/iter.rs
@@ -10,9 +10,9 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let word_start = self.line.find(self.word_begin)?;
 
-        let word_end = self.line[word_start..]
+        let word_end = self.line[word_start + 1..]
             .find(self.word_end)
-            .map(|i| i + word_start)
+            .map(|i| i + word_start + 1)
             .unwrap_or(self.line.len());
 
         let word = &self.line[word_start..word_end];

--- a/src/wordifier/mod.rs
+++ b/src/wordifier/mod.rs
@@ -1,6 +1,9 @@
 mod basic;
+mod camel;
+mod iter;
 
 pub use basic::BasicWordifier;
+pub use camel::CamelCaseWordifier;
 
 pub trait Wordifier {
     fn words<'a>(&self, line: &'a str) -> impl Iterator<Item = &'a str>;


### PR DESCRIPTION
Adds an implementation of `Wordifier` that considers an uppercased letter as word end / begin to support spell checking `camelCased` identifier names.

- Adds tests
- Updates `Iter` to hold predicates for reusability
- Makes sure the word supplied from `Iter` is never empty